### PR TITLE
feat: add swagger related and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ api/
 |--------|----------|-------------|
 | GET    | `/health` | Health check endpoint |
 
+### Swagger UI
+- link: [http://localhost:8080/swagger/index.html](http://localhost:8080/swagger/index.html)
 ## Task Model
 
 ```json

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,8 +12,29 @@ import (
 	"github.com/amoylab/solo-api/pkg/logger"
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/cobra"
+	swaggerFiles "github.com/swaggo/files"
+	ginSwagger "github.com/swaggo/gin-swagger"
 	"go.uber.org/zap"
+
+	_ "github.com/amoylab/solo-api/docs"
 )
+
+// @title           Solo API
+// @version         1.0.0
+// @description     A RESTful API server for managing tasks and projects in Solo application
+// @termsOfService  http://swagger.io/terms/
+
+// @contact.name   API Support
+// @contact.url    http://www.swagger.io/support
+// @contact.email  support@swagger.io
+
+// @license.name  Apache 2.0
+// @license.url   http://www.apache.org/licenses/LICENSE-2.0.html
+
+// @host      localhost:8080
+// @BasePath  /api
+
+// @securityDefinitions.basic  BasicAuth
 
 var (
 	configPath string
@@ -77,12 +98,22 @@ func setupRouter(taskHandler *handler.TaskHandler, projectHandler *handler.Proje
 	router.Use(corsMiddleware())
 
 	// Health check endpoint
+	// @Summary Health check
+	// @Description Check the health status of the API
+	// @Tags health
+	// @Accept json
+	// @Produce json
+	// @Success 200 {object} map[string]interface{}
+	// @Router /health [get]
 	router.GET("/health", func(c *gin.Context) {
 		c.JSON(200, gin.H{
 			"status":  "healthy",
 			"service": "solo-api",
 		})
 	})
+
+	// Swagger UI
+	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
 	// API routes
 	api := router.Group("/api")

--- a/go.mod
+++ b/go.mod
@@ -15,14 +15,22 @@ require (
 )
 
 require (
+	github.com/KyleBanks/depth v1.2.1 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/bytedance/sonic v1.11.6 // indirect
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/glebarez/go-sqlite v1.21.2 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.19.6 // indirect
+	github.com/go-openapi/spec v0.20.4 // indirect
+	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.20.0 // indirect
@@ -30,26 +38,36 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/swaggo/files v1.0.1 // indirect
+	github.com/swaggo/gin-swagger v1.6.0 // indirect
+	github.com/swaggo/swag v1.16.4 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
+	github.com/urfave/cli/v2 v2.3.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/text v0.15.0 // indirect
+	golang.org/x/tools v0.7.0 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	modernc.org/libc v1.22.5 // indirect
 	modernc.org/mathutil v1.5.0 // indirect
 	modernc.org/memory v1.5.0 // indirect
 	modernc.org/sqlite v1.23.1 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/internal/handler/task.go
+++ b/internal/handler/task.go
@@ -23,6 +23,16 @@ func NewTaskHandler(taskService *service.TaskService, logger *zap.Logger) *TaskH
 }
 
 // CreateTask handles POST /api/tasks
+// @Summary Create a new task
+// @Description Create a new task with the provided details
+// @Tags tasks
+// @Accept json
+// @Produce json
+// @Param task body model.CreateTaskRequest true "Task creation request"
+// @Success 201 {object} model.TaskResponse
+// @Failure 400 {object} map[string]interface{}
+// @Failure 500 {object} map[string]interface{}
+// @Router /tasks [post]
 func (h *TaskHandler) CreateTask(c *gin.Context) {
 	var req model.CreateTaskRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -57,6 +67,17 @@ func (h *TaskHandler) CreateTask(c *gin.Context) {
 }
 
 // GetTask handles GET /api/tasks/:id
+// @Summary Get a task by ID
+// @Description Get a specific task by its ID
+// @Tags tasks
+// @Accept json
+// @Produce json
+// @Param id path string true "Task ID"
+// @Success 200 {object} model.TaskResponse
+// @Failure 400 {object} map[string]interface{}
+// @Failure 404 {object} map[string]interface{}
+// @Failure 500 {object} map[string]interface{}
+// @Router /tasks/{id} [get]
 func (h *TaskHandler) GetTask(c *gin.Context) {
 	id := c.Param("id")
 	if id == "" {
@@ -89,6 +110,14 @@ func (h *TaskHandler) GetTask(c *gin.Context) {
 }
 
 // GetTasks handles GET /api/tasks
+// @Summary Get all tasks
+// @Description Get a list of all tasks
+// @Tags tasks
+// @Accept json
+// @Produce json
+// @Success 200 {object} model.TaskListResponse
+// @Failure 500 {object} map[string]interface{}
+// @Router /tasks [get]
 func (h *TaskHandler) GetTasks(c *gin.Context) {
 	tasks, err := h.taskService.GetTasks()
 	if err != nil {
@@ -104,6 +133,18 @@ func (h *TaskHandler) GetTasks(c *gin.Context) {
 }
 
 // UpdateTask handles PUT /api/tasks/:id
+// @Summary Update a task
+// @Description Update a task with the provided details
+// @Tags tasks
+// @Accept json
+// @Produce json
+// @Param id path string true "Task ID"
+// @Param task body model.UpdateTaskRequest true "Task update request"
+// @Success 200 {object} model.TaskResponse
+// @Failure 400 {object} map[string]interface{}
+// @Failure 404 {object} map[string]interface{}
+// @Failure 500 {object} map[string]interface{}
+// @Router /tasks/{id} [put]
 func (h *TaskHandler) UpdateTask(c *gin.Context) {
 	id := c.Param("id")
 	if id == "" {
@@ -154,6 +195,17 @@ func (h *TaskHandler) UpdateTask(c *gin.Context) {
 }
 
 // DeleteTask handles DELETE /api/tasks/:id
+// @Summary Delete a task
+// @Description Delete a task by its ID
+// @Tags tasks
+// @Accept json
+// @Produce json
+// @Param id path string true "Task ID"
+// @Success 204
+// @Failure 400 {object} map[string]interface{}
+// @Failure 404 {object} map[string]interface{}
+// @Failure 500 {object} map[string]interface{}
+// @Router /tasks/{id} [delete]
 func (h *TaskHandler) DeleteTask(c *gin.Context) {
 	id := c.Param("id")
 	if id == "" {


### PR DESCRIPTION
## Summary by Sourcery

Integrate Swagger documentation into the API by adding annotations, serving the Swagger UI endpoint, updating dependencies, and linking the documentation in the README.

New Features:
- Expose Swagger UI endpoint at /swagger/*any to serve API documentation

Enhancements:
- Annotate TaskHandler methods and health check with Swagger comments
- Add Swagger metadata comments in main.go for API title, version, host, and security definitions
- Include Swagger-related dependencies in go.mod for documentation generation

Documentation:
- Update README.md to add a link to the Swagger UI